### PR TITLE
More languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,12 @@
 This extension allows you to print a list of regions in a document and select a region to navigate to the document's location.
 
 The languages supported are as follows.
- - C#
+ - TypeScript/JavaScript: `//#region` and `//region`
+ - C#: `#region`
+ - C/C++: `#pragma region`
+ - F#: `//#region`
+ - PowerShell: `#region`
+ - VB: `#Region`
 
 ## Known Issues
 

--- a/santacodes-region-viewer/README.md
+++ b/santacodes-region-viewer/README.md
@@ -3,7 +3,12 @@
 This extension allows you to print a list of regions in a document and select a region to navigate to the document's location.
 
 The languages supported are as follows.
- - C#
+ - TypeScript/JavaScript: `//#region` and `//region`
+ - C#: `#region`
+ - C/C++: `#pragma region`
+ - F#: `//#region`
+ - PowerShell: `#region`
+ - VB: `#Region`
 
 ## Known Issues
 

--- a/santacodes-region-viewer/src/regionTreeDataProvider.ts
+++ b/santacodes-region-viewer/src/regionTreeDataProvider.ts
@@ -39,11 +39,26 @@ export class RegionTreeDataProvider implements vscode.TreeDataProvider<Dependenc
 			if (text == undefined)
 				continue;
 
-			if (text.includes("#region") == false)
-				continue;
+            // Region markers as they're documented in:
+            // https://code.visualstudio.com/updates/v1_17#_folding-regions
+            const regionMarkers = [
+                "//#region",
+                "//region",
+                "#region",
+                "#pragma region",
+                "#Region"
+            ]
 
-			let name = text.replace("#region", "#").trim();
-			treeRoot.push(new Dependency(name, i, vscode.TreeItemCollapsibleState.None));
+            for (const marker of regionMarkers) {
+                // Check if line starts with on of the region markers
+                if(text.trim().startsWith(marker)) {
+                    let name = text.replace(marker, "").trim(); // remove first marker
+                    if (name.length === 0) name = "region"; // ensure name is not empty
+                    name = "# " + name; // prepend with the # symbol
+
+                    treeRoot.push(new Dependency(name, i, vscode.TreeItemCollapsibleState.None));
+                }
+            }
 		}
 		this.data = treeRoot;
 	}

--- a/santacodes-region-viewer/src/regionTreeDataProvider.ts
+++ b/santacodes-region-viewer/src/regionTreeDataProvider.ts
@@ -39,26 +39,26 @@ export class RegionTreeDataProvider implements vscode.TreeDataProvider<Dependenc
 			if (text == undefined)
 				continue;
 
-            // Region markers as they're documented in:
-            // https://code.visualstudio.com/updates/v1_17#_folding-regions
-            const regionMarkers = [
-                "//#region",
-                "//region",
-                "#region",
-                "#pragma region",
-                "#Region"
-            ]
+			// Region markers as they're documented in:
+			// https://code.visualstudio.com/updates/v1_17#_folding-regions
+			const regionMarkers = [
+				"//#region",
+				"//region",
+				"#region",
+				"#pragma region",
+				"#Region"
+			]
 
-            for (const marker of regionMarkers) {
-                // Check if line starts with on of the region markers
-                if(text.trim().startsWith(marker)) {
-                    let name = text.replace(marker, "").trim(); // remove first marker
-                    if (name.length === 0) name = "region"; // ensure name is not empty
-                    name = "# " + name; // prepend with the # symbol
+			for (const marker of regionMarkers) {
+				// Check if line starts with on of the region markers
+				if(text.trim().startsWith(marker)) {
+					let name = text.replace(marker, "").trim(); // remove first marker
+					if (name.length === 0) name = "region"; // ensure name is not empty
+					name = "# " + name; // prepend with the # symbol
 
-                    treeRoot.push(new Dependency(name, i, vscode.TreeItemCollapsibleState.None));
-                }
-            }
+					treeRoot.push(new Dependency(name, i, vscode.TreeItemCollapsibleState.None));
+				}
+			}
 		}
 		this.data = treeRoot;
 	}


### PR DESCRIPTION
Hi!

I really like your extension! At least until there's an official region outline support.

Here's my proposal for extending it to support all the region markers listed in https://code.visualstudio.com/updates/v1_17#_folding-regions

It should be fairly general. Instead of your `text.includes("#region")`, I opted for `text.trim().startsWith("#region")` to avoid any false positives. I tested it on my Typescript project and various libraries and found no false positives.

I also made some subjective changes. Tell me if you don't like some (or either) of these behaviors. No hard feelings. 😄

1. If there's a region marker with nothing else, the displayed name is still region. I think this is more appealing than simply displaying a "#".
![image](https://user-images.githubusercontent.com/24359130/88576298-83285200-d045-11ea-9efd-e0c19a8a4d64.png)

2. The region names are now trimmed.
![image](https://user-images.githubusercontent.com/24359130/88576365-9c310300-d045-11ea-9fcf-4e4f7efbf208.png)

I'd love to get this merged. I'll be happy to tweak things based on your feedback.
Thanks!