### PR TITLE
More languages, nesting, regex patterns

### DIFF
--- a/santacodes-region-viewer/src/markers.json
+++ b/santacodes-region-viewer/src/markers.json
@@ -52,7 +52,7 @@
 		"end": "^\\s*(#|\/\/)endregion\\b"
 	},
 	"perl": {
-		"start": "^\\s*#region\\b(?<nameAlt>.*)",
+		"start": "^\\s*#region\\b(?<name>.*)",
 		"end": "^\\s*#endregion\\b"
 	},
 	"powershell": {

--- a/santacodes-region-viewer/src/markers.json
+++ b/santacodes-region-viewer/src/markers.json
@@ -20,7 +20,7 @@
 		"end": "^\\s*\\/\\*\\s*#endregion\\b.*\\*\\/"
 	},
 	"fsharp": {
-		"start": "^\\s*//\\s*#region\\b|^\\s*\\(\\*\\s*#region(.*)\\*\\)",
+		"start": "^\\s*//\\s*#region\\b(?<name>.*)|^\\s*\\(\\*\\s*#region(?<nameAlt>.*)\\*\\)",
 		"end": "^\\s*//\\s*#endregion\\b|^\\s*\\(\\*\\s*#endregion\\s*\\*\\)"
 	},
 	"go": {
@@ -32,8 +32,8 @@
 		"end": "^\\s*<!--\\s*#endregion\\b.*-->"
 	},
 	"java": {
-		"start": "^\\s*//\\s*(?:(?:#?region\\b)|(?:<editor-fold\\b))",
-		"end": "^\\s*//\\s*(?:(?:#?endregion\\b)|(?:</editor-fold>))"
+		"start": "^\\s*//\\s*(?:(?:#?region\\b(?<name>.*))",
+		"end": "^\\s*//\\s*(?:(?:#?endregion\\b)"
 	},
 	"javascript": {
 		"start": "^\\s*//\\s*#?region\\b(?<name>.*)",
@@ -52,7 +52,7 @@
 		"end": "^\\s*(#|\/\/)endregion\\b"
 	},
 	"perl": {
-		"start": "^(?:(?:=pod\\s*$)|(?:\\s*#region\\b))",
+		"start": "^(?:(?:=pod(?<name>.*)$)|(?:\\s*#region\\b(?<nameAlt>.*)))",
 		"end": "^(?:(?:=cut\\s*$)|(?:\\s*#endregion\\b))"
 	},
 	"powershell": {
@@ -80,7 +80,7 @@
 		"end": "^\\s*//\\s*#?endregion\\b"
 	},
 	"vb": {
-		"start": "^\\s*#Region\\b",
+		"start": "^\\s*#Region\\b\\s*\"(?<name>.*)\"",
 		"end": "^\\s*#End Region\\b"
 	},
 	"xml": {

--- a/santacodes-region-viewer/src/markers.json
+++ b/santacodes-region-viewer/src/markers.json
@@ -4,19 +4,19 @@
 		"end": "^\\s*(::\\s*|REM\\s+)#endregion"
 	},
 	"coffeescript": {
-		"start": "^\\s*#region\\b",
+		"start": "^\\s*#region\\b(?<name>.*)",
 		"end": "^\\s*#endregion\\b"
 	},
 	"cpp": {
-		"start": "^\\s*#pragma\\s+region\\b",
+		"start": "^\\s*#pragma\\s+region\\b(?<name>.*)",
 		"end": "^\\s*#pragma\\s+endregion\\b"
 	},
 	"csharp": {
-		"start": "^\\s*#region\\b",
+		"start": "^\\s*#region\\b(?<name>.*)",
 		"end": "^\\s*#endregion\\b"
 	},
 	"css": {
-		"start": "^\\s*\\/\\*\\s*#region\\b\\s*(.*?)\\s*\\*\\/",
+		"start": "^\\s*\\/\\*\\s*#region\\b(?<name>.*)\\s*\\*\\/",
 		"end": "^\\s*\\/\\*\\s*#endregion\\b.*\\*\\/"
 	},
 	"fsharp": {
@@ -24,11 +24,11 @@
 		"end": "^\\s*//\\s*#endregion\\b|^\\s*\\(\\*\\s*#endregion\\s*\\*\\)"
 	},
 	"go": {
-		"start": "^\\s*//\\s*#?region\\b",
+		"start": "^\\s*//\\s*#?region\\b(?<name>.*)",
 		"end": "^\\s*//\\s*#?endregion\\b"
 	},
 	"html": {
-		"start": "^\\s*<!--\\s*#region\\b.*-->",
+		"start": "^\\s*<!--\\s*#region\\b(?<name>.*)-->",
 		"end": "^\\s*<!--\\s*#endregion\\b.*-->"
 	},
 	"java": {
@@ -36,19 +36,19 @@
 		"end": "^\\s*//\\s*(?:(?:#?endregion\\b)|(?:</editor-fold>))"
 	},
 	"javascript": {
-		"start": "^\\s*//\\s*#?region\\b",
+		"start": "^\\s*//\\s*#?region\\b(?<name>.*)",
 		"end": "^\\s*//\\s*#?endregion\\b"
 	},
 	"less": {
-		"start": "^\\s*\\/\\*\\s*#region\\b\\s*(.*?)\\s*\\*\\/",
+		"start": "^\\s*\\/\\*\\s*#region\\b(?<name>.*)\\s*\\*\\/",
 		"end": "^\\s*\\/\\*\\s*#endregion\\b.*\\*\\/"
 	},
 	"markdown": {
-		"start": "^\\s*<!--\\s*#?region\\b.*-->",
+		"start": "^\\s*<!--\\s*#?region\\b(?<name>.*)-->",
 		"end": "^\\s*<!--\\s*#?endregion\\b.*-->"
 	},
 	"php": {
-		"start": "^\\s*(#|\/\/)region\\b",
+		"start": "^\\s*(#|\/\/)region\\b(?<name>.*)",
 		"end": "^\\s*(#|\/\/)endregion\\b"
 	},
 	"perl": {
@@ -56,27 +56,27 @@
 		"end": "^(?:(?:=cut\\s*$)|(?:\\s*#endregion\\b))"
 	},
 	"powershell": {
-		"start": "^\\s*#[rR]egion\\b",
+		"start": "^\\s*#[rR]egion\\b(?<name>.*)",
 		"end": "^\\s*#[eE]nd[rR]egion\\b"
 	},
 	"python": {
-		"start": "^\\s*#\\s*region\\b",
+		"start": "^\\s*#\\s*region\\b(?<name>.*)",
 		"end": "^\\s*#\\s*endregion\\b"
 	},
 	"rust": {
-		"start": "^\\s*//\\s*#?region\\b",
+		"start": "^\\s*//\\s*#?region\\b(?<name>.*)",
 		"end": "^\\s*//\\s*#?endregion\\b"
 	},
 	"scss": {
-		"start": "^\\s*\\/\\*\\s*#region\\b\\s*(.*?)\\s*\\*\\/",
+		"start": "^\\s*\\/\\*\\s*#region\\b(?<name>.*)\\s*\\*\\/",
 		"end": "^\\s*\\/\\*\\s*#endregion\\b.*\\*\\/"
 	},
 	"shellscript": {
-		"start": "^\\s*#\\s*#?region\\b.*",
+		"start": "^\\s*#\\s*#?region\\b(?<name>.*)",
 		"end": "^\\s*#\\s*#?endregion\\b.*"
 	},
 	"typescript": {
-		"start": "^\\s*//\\s*#?region\\b",
+		"start": "^\\s*//\\s*#?region\\b(?<name>.*)",
 		"end": "^\\s*//\\s*#?endregion\\b"
 	},
 	"vb": {
@@ -84,11 +84,11 @@
 		"end": "^\\s*#End Region\\b"
 	},
 	"xml": {
-		"start": "^\\s*<!--\\s*#region\\b.*-->",
+		"start": "^\\s*<!--\\s*#region\\b(?<name>.*)-->",
 		"end": "^\\s*<!--\\s*#endregion\\b.*-->"
 	},
 	"yaml": {
-		"start": "^\\s*#\\s*region\\b",
+		"start": "^\\s*#\\s*region\\b(?<name>.*)",
 		"end": "^\\s*#\\s*endregion\\b"
 	}
 }

--- a/santacodes-region-viewer/src/markers.json
+++ b/santacodes-region-viewer/src/markers.json
@@ -1,19 +1,7 @@
 {
-	"vb": {
-		"start": "^\\s*#Region\\b",
-		"end": "^\\s*#End Region\\b"
-	},
-	"yaml": {
-		"start": "^\\s*#\\s*region\\b",
-		"end": "^\\s*#\\s*endregion\\b"
-	},
 	"bat": {
 		"start": "^\\s*(::\\s*|REM\\s+)#region",
 		"end": "^\\s*(::\\s*|REM\\s+)#endregion"
-	},
-	"perl": {
-		"start": "^(?:(?:=pod\\s*$)|(?:\\s*#region\\b))",
-		"end": "^(?:(?:=cut\\s*$)|(?:\\s*#endregion\\b))"
 	},
 	"coffeescript": {
 		"start": "^\\s*#region\\b",
@@ -27,39 +15,27 @@
 		"start": "^\\s*#region\\b",
 		"end": "^\\s*#endregion\\b"
 	},
+	"css": {
+		"start": "^\\s*\\/\\*\\s*#region\\b\\s*(.*?)\\s*\\*\\/",
+		"end": "^\\s*\\/\\*\\s*#endregion\\b.*\\*\\/"
+	},
 	"fsharp": {
 		"start": "^\\s*//\\s*#region\\b|^\\s*\\(\\*\\s*#region(.*)\\*\\)",
 		"end": "^\\s*//\\s*#endregion\\b|^\\s*\\(\\*\\s*#endregion\\s*\\*\\)"
+	},
+	"go": {
+		"start": "^\\s*//\\s*#?region\\b",
+		"end": "^\\s*//\\s*#?endregion\\b"
+	},
+	"html": {
+		"start": "^\\s*<!--\\s*#region\\b.*-->",
+		"end": "^\\s*<!--\\s*#endregion\\b.*-->"
 	},
 	"java": {
 		"start": "^\\s*//\\s*(?:(?:#?region\\b)|(?:<editor-fold\\b))",
 		"end": "^\\s*//\\s*(?:(?:#?endregion\\b)|(?:</editor-fold>))"
 	},
-	"rust": {
-		"start": "^\\s*//\\s*#?region\\b",
-		"end": "^\\s*//\\s*#?endregion\\b"
-	},
-	"shellscript": {
-		"start": "^\\s*#\\s*#?region\\b.*",
-		"end": "^\\s*#\\s*#?endregion\\b.*"
-	},
-	"markdown": {
-		"start": "^\\s*<!--\\s*#?region\\b.*-->",
-		"end": "^\\s*<!--\\s*#?endregion\\b.*-->"
-	},
-	"css": {
-		"start": "^\\s*\\/\\*\\s*#region\\b\\s*(.*?)\\s*\\*\\/",
-		"end": "^\\s*\\/\\*\\s*#endregion\\b.*\\*\\/"
-	},
-	"powershell": {
-		"start": "^\\s*#[rR]egion\\b",
-		"end": "^\\s*#[eE]nd[rR]egion\\b"
-	},
-	"php": {
-		"start": "^\\s*(#|\/\/)region\\b",
-		"end": "^\\s*(#|\/\/)endregion\\b"
-	},
-	"go": {
+	"javascript": {
 		"start": "^\\s*//\\s*#?region\\b",
 		"end": "^\\s*//\\s*#?endregion\\b"
 	},
@@ -67,11 +43,27 @@
 		"start": "^\\s*\\/\\*\\s*#region\\b\\s*(.*?)\\s*\\*\\/",
 		"end": "^\\s*\\/\\*\\s*#endregion\\b.*\\*\\/"
 	},
-	"html": {
-		"start": "^\\s*<!--\\s*#region\\b.*-->",
-		"end": "^\\s*<!--\\s*#endregion\\b.*-->"
+	"markdown": {
+		"start": "^\\s*<!--\\s*#?region\\b.*-->",
+		"end": "^\\s*<!--\\s*#?endregion\\b.*-->"
 	},
-	"javascript": {
+	"php": {
+		"start": "^\\s*(#|\/\/)region\\b",
+		"end": "^\\s*(#|\/\/)endregion\\b"
+	},
+	"perl": {
+		"start": "^(?:(?:=pod\\s*$)|(?:\\s*#region\\b))",
+		"end": "^(?:(?:=cut\\s*$)|(?:\\s*#endregion\\b))"
+	},
+	"powershell": {
+		"start": "^\\s*#[rR]egion\\b",
+		"end": "^\\s*#[eE]nd[rR]egion\\b"
+	},
+	"python": {
+		"start": "^\\s*#\\s*region\\b",
+		"end": "^\\s*#\\s*endregion\\b"
+	},
+	"rust": {
 		"start": "^\\s*//\\s*#?region\\b",
 		"end": "^\\s*//\\s*#?endregion\\b"
 	},
@@ -79,15 +71,23 @@
 		"start": "^\\s*\\/\\*\\s*#region\\b\\s*(.*?)\\s*\\*\\/",
 		"end": "^\\s*\\/\\*\\s*#endregion\\b.*\\*\\/"
 	},
+	"shellscript": {
+		"start": "^\\s*#\\s*#?region\\b.*",
+		"end": "^\\s*#\\s*#?endregion\\b.*"
+	},
 	"typescript": {
 		"start": "^\\s*//\\s*#?region\\b",
 		"end": "^\\s*//\\s*#?endregion\\b"
+	},
+	"vb": {
+		"start": "^\\s*#Region\\b",
+		"end": "^\\s*#End Region\\b"
 	},
 	"xml": {
 		"start": "^\\s*<!--\\s*#region\\b.*-->",
 		"end": "^\\s*<!--\\s*#endregion\\b.*-->"
 	},
-	"python": {
+	"yaml": {
 		"start": "^\\s*#\\s*region\\b",
 		"end": "^\\s*#\\s*endregion\\b"
 	}

--- a/santacodes-region-viewer/src/markers.json
+++ b/santacodes-region-viewer/src/markers.json
@@ -1,6 +1,6 @@
 {
 	"bat": {
-		"start": "^\\s*(::\\s*|REM\\s+)#region",
+		"start": "^\\s*(::\\s*|REM\\s+)#region(?<name>.*)",
 		"end": "^\\s*(::\\s*|REM\\s+)#endregion"
 	},
 	"coffeescript": {

--- a/santacodes-region-viewer/src/markers.json
+++ b/santacodes-region-viewer/src/markers.json
@@ -1,0 +1,94 @@
+{
+	"vb": {
+		"start": "^\\s*#Region\\b",
+		"end": "^\\s*#End Region\\b"
+	},
+	"yaml": {
+		"start": "^\\s*#\\s*region\\b",
+		"end": "^\\s*#\\s*endregion\\b"
+	},
+	"bat": {
+		"start": "^\\s*(::\\s*|REM\\s+)#region",
+		"end": "^\\s*(::\\s*|REM\\s+)#endregion"
+	},
+	"perl": {
+		"start": "^(?:(?:=pod\\s*$)|(?:\\s*#region\\b))",
+		"end": "^(?:(?:=cut\\s*$)|(?:\\s*#endregion\\b))"
+	},
+	"coffeescript": {
+		"start": "^\\s*#region\\b",
+		"end": "^\\s*#endregion\\b"
+	},
+	"cpp": {
+		"start": "^\\s*#pragma\\s+region\\b",
+		"end": "^\\s*#pragma\\s+endregion\\b"
+	},
+	"csharp": {
+		"start": "^\\s*#region\\b",
+		"end": "^\\s*#endregion\\b"
+	},
+	"fsharp": {
+		"start": "^\\s*//\\s*#region\\b|^\\s*\\(\\*\\s*#region(.*)\\*\\)",
+		"end": "^\\s*//\\s*#endregion\\b|^\\s*\\(\\*\\s*#endregion\\s*\\*\\)"
+	},
+	"java": {
+		"start": "^\\s*//\\s*(?:(?:#?region\\b)|(?:<editor-fold\\b))",
+		"end": "^\\s*//\\s*(?:(?:#?endregion\\b)|(?:</editor-fold>))"
+	},
+	"rust": {
+		"start": "^\\s*//\\s*#?region\\b",
+		"end": "^\\s*//\\s*#?endregion\\b"
+	},
+	"shellscript": {
+		"start": "^\\s*#\\s*#?region\\b.*",
+		"end": "^\\s*#\\s*#?endregion\\b.*"
+	},
+	"markdown": {
+		"start": "^\\s*<!--\\s*#?region\\b.*-->",
+		"end": "^\\s*<!--\\s*#?endregion\\b.*-->"
+	},
+	"css": {
+		"start": "^\\s*\\/\\*\\s*#region\\b\\s*(.*?)\\s*\\*\\/",
+		"end": "^\\s*\\/\\*\\s*#endregion\\b.*\\*\\/"
+	},
+	"powershell": {
+		"start": "^\\s*#[rR]egion\\b",
+		"end": "^\\s*#[eE]nd[rR]egion\\b"
+	},
+	"php": {
+		"start": "^\\s*(#|\/\/)region\\b",
+		"end": "^\\s*(#|\/\/)endregion\\b"
+	},
+	"go": {
+		"start": "^\\s*//\\s*#?region\\b",
+		"end": "^\\s*//\\s*#?endregion\\b"
+	},
+	"less": {
+		"start": "^\\s*\\/\\*\\s*#region\\b\\s*(.*?)\\s*\\*\\/",
+		"end": "^\\s*\\/\\*\\s*#endregion\\b.*\\*\\/"
+	},
+	"html": {
+		"start": "^\\s*<!--\\s*#region\\b.*-->",
+		"end": "^\\s*<!--\\s*#endregion\\b.*-->"
+	},
+	"javascript": {
+		"start": "^\\s*//\\s*#?region\\b",
+		"end": "^\\s*//\\s*#?endregion\\b"
+	},
+	"scss": {
+		"start": "^\\s*\\/\\*\\s*#region\\b\\s*(.*?)\\s*\\*\\/",
+		"end": "^\\s*\\/\\*\\s*#endregion\\b.*\\*\\/"
+	},
+	"typescript": {
+		"start": "^\\s*//\\s*#?region\\b",
+		"end": "^\\s*//\\s*#?endregion\\b"
+	},
+	"xml": {
+		"start": "^\\s*<!--\\s*#region\\b.*-->",
+		"end": "^\\s*<!--\\s*#endregion\\b.*-->"
+	},
+	"python": {
+		"start": "^\\s*#\\s*region\\b",
+		"end": "^\\s*#\\s*endregion\\b"
+	}
+}

--- a/santacodes-region-viewer/src/markers.json
+++ b/santacodes-region-viewer/src/markers.json
@@ -52,8 +52,8 @@
 		"end": "^\\s*(#|\/\/)endregion\\b"
 	},
 	"perl": {
-		"start": "^(?:(?:=pod(?<name>.*)$)|(?:\\s*#region\\b(?<nameAlt>.*)))",
-		"end": "^(?:(?:=cut\\s*$)|(?:\\s*#endregion\\b))"
+		"start": "^\\s*#region\\b(?<nameAlt>.*)",
+		"end": "^\\s*#endregion\\b"
 	},
 	"powershell": {
 		"start": "^\\s*#[rR]egion\\b(?<name>.*)",

--- a/santacodes-region-viewer/src/regionTreeDataProvider.ts
+++ b/santacodes-region-viewer/src/regionTreeDataProvider.ts
@@ -36,8 +36,6 @@ export class RegionTreeDataProvider implements vscode.TreeDataProvider<Dependenc
 		let treeRoot: Dependency[] = [];
 		let regionStack: Dependency[] = [];
 
-		// console.log(new RegExp(markers.start.csharp).test("#region"));
-
 		if (document.languageId in markers)
 		{
 			const indexableMarkings: {[language: string]: { "start": string, "end": string}} = markers;
@@ -57,8 +55,6 @@ export class RegionTreeDataProvider implements vscode.TreeDataProvider<Dependenc
 				let text = document.getText(range);
 				if (text == undefined)
 					continue;
-	
-				// const trimmedText = text.trim();
 	
 				if (isRegionStart(text)) {
 					const name = text;	// TODO use regex groups
@@ -92,38 +88,6 @@ export class RegionTreeDataProvider implements vscode.TreeDataProvider<Dependenc
 			this.data = treeRoot;
 		}
 	}
-
-	// More concise way to handle / recognize nesting?
-	// https://github.com/microsoft/vscode/blob/f74e473238aca7b79c08be761d99a0232838ca4c/extensions/markdown-language-features/src/features/foldingProvider.ts#L39-L57
-
-	// private async getRegions(document: vscode.TextDocument): Promise<vscode.FoldingRange[]> {
-	// 	const tokens = await this.engine.parse(document);
-	// 	const regionMarkers = tokens.filter(isRegionMarker)
-	// 		.map(token => ({ line: token.map[0], isStart: isStartRegion(token.content) }));
-
-	// 	const nestingStack: { line: number, isStart: boolean }[] = [];
-	// 	return regionMarkers
-	// 		.map(marker => {
-	// 			if (marker.isStart) {
-	// 				nestingStack.push(marker);
-	// 			} else if (nestingStack.length && nestingStack[nestingStack.length - 1].isStart) {
-	// 				return new vscode.FoldingRange(nestingStack.pop()!.line, marker.line, vscode.FoldingRangeKind.Region);
-	// 			} else {
-	// 				// noop: invalid nesting (i.e. [end, start] or [start, end, end])
-	// 			}
-	// 			return null;
-	// 		})
-	// 		.filter((region: vscode.FoldingRange | null): region is vscode.FoldingRange => !!region);
-	// }
-
-	// private getRegionName(line: string, marker: string): string {
-	// 	// Remove first marker
-	// 	let name = line.replace(marker, "").trim();
-	// 	// Ensure name is not empty
-	// 	if (name.length === 0) name = "region";
-	// 	// Prepend with the # symbol
-	// 	return "# " + name;
-	// }
 }
 
 class Dependency extends vscode.TreeItem {

--- a/santacodes-region-viewer/src/regionTreeDataProvider.ts
+++ b/santacodes-region-viewer/src/regionTreeDataProvider.ts
@@ -59,7 +59,18 @@ export class RegionTreeDataProvider implements vscode.TreeDataProvider<Dependenc
 					continue;
 	
 				if (isRegionStart(text)) {
-					const name = text;	// TODO use regex groups
+					const result = startRegExp.exec(text);
+
+					let name: string;
+					if (result && result.groups && "name" in result.groups) {
+						name = result.groups["name"].trim();
+						if (name.length === 0) name = "region";
+						name = "# " + name;
+					}
+					else {
+						name = text;
+					}
+					
 					const dep = new Dependency(name, i);
 
 					// If we have a parent, register as their child

--- a/santacodes-region-viewer/src/regionTreeDataProvider.ts
+++ b/santacodes-region-viewer/src/regionTreeDataProvider.ts
@@ -38,10 +38,12 @@ export class RegionTreeDataProvider implements vscode.TreeDataProvider<Dependenc
 
 		if (document.languageId in markers)
 		{
-			const indexableMarkings: {[language: string]: { "start": string, "end": string}} = markers;
+			// Create Generally Typed Markers, so that we can
+			// index them using languageID strings
+			const GTMarkers: {[language: string]: { "start": string, "end": string}} = markers;
 
-			const startRegExp = new RegExp(indexableMarkings[document.languageId].start);
-			const endRegExp = new RegExp(indexableMarkings[document.languageId].end);
+			const startRegExp = new RegExp(GTMarkers[document.languageId].start);
+			const endRegExp = new RegExp(GTMarkers[document.languageId].end);
 
 			const isRegionStart = (t: string) => startRegExp.test(t);
 			const isRegionEnd = (t: string) => endRegExp.test(t);

--- a/santacodes-region-viewer/src/regionTreeDataProvider.ts
+++ b/santacodes-region-viewer/src/regionTreeDataProvider.ts
@@ -19,8 +19,13 @@ export class RegionTreeDataProvider implements vscode.TreeDataProvider<Dependenc
 		return element;
 	}
 
-	getChildren(element?: Dependency): Thenable<Dependency[]> {
-		return Promise.resolve(this.data!);
+	getChildren(element?: Dependency): vscode.ProviderResult<Dependency[]> {
+		
+		if (element === undefined) {
+			return this.data;
+		}
+
+		return element.children;
 	}
 
 	private findRegion(): void {
@@ -29,6 +34,8 @@ export class RegionTreeDataProvider implements vscode.TreeDataProvider<Dependenc
 			return
 
 		let treeRoot = [];
+		let regionStack = [];
+
 		for (let i = 0; i < document.lineCount; i++) {
 			const line = document.lineAt(i);
 			if (line == undefined)
@@ -41,7 +48,7 @@ export class RegionTreeDataProvider implements vscode.TreeDataProvider<Dependenc
 
 			// Region markers as they're documented in:
 			// https://code.visualstudio.com/updates/v1_17#_folding-regions
-			const regionMarkers = [
+			const startMarkers = [
 				"//#region",
 				"//region",
 				"#region",
@@ -49,24 +56,68 @@ export class RegionTreeDataProvider implements vscode.TreeDataProvider<Dependenc
 				"#Region"
 			]
 
-			for (const marker of regionMarkers) {
-				// Check if line starts with on of the region markers
-				if(text.trim().startsWith(marker)) {
-					let name = text.replace(marker, "").trim(); // remove first marker
-					if (name.length === 0) name = "region"; // ensure name is not empty
-					name = "# " + name; // prepend with the # symbol
+			const endMarkers = [
+				"//#endregion",
+				"//endregion",
+				"#endregion",
+				"#pragma endregion",
+				"#End Region"
+			]
 
-					treeRoot.push(new Dependency(name, i, vscode.TreeItemCollapsibleState.None));
+			// Region start
+			for (const marker of startMarkers) {
+				if(text.trim().startsWith(marker)) {
+					const name = this.getRegionName(text, marker);
+					const dep = new Dependency(name, i);
+
+					if (regionStack.length > 0) {
+						let parentDep = regionStack[regionStack.length - 1];
+						parentDep.children?.push(dep);
+						parentDep.collapsibleState =  vscode.TreeItemCollapsibleState.Collapsed;	// Possibly optimise
+					}
+
+					regionStack.push(dep);
+				}
+			}
+
+			// Region end
+			for (const marker of endMarkers) {
+				if(text.trim().startsWith(marker)) {
+					if (regionStack.length === 1) {
+						treeRoot.push(regionStack[0]);
+					}
+
+					regionStack.pop();
 				}
 			}
 		}
+
+		// Resolve remaining stack entries
+		// These regions were opened but never closed
+		if (regionStack.length > 0) {
+			treeRoot.push(regionStack[0]);
+		}
+
 		this.data = treeRoot;
+	}
+
+	private getRegionName(line: string, marker: string): string {
+		// remove first marker
+		let name = line.replace(marker, "").trim();
+		// ensure name is not empty
+		if (name.length === 0) name = "region";
+		// prepend with the # symbol
+		return "# " + name;
 	}
 }
 
 class Dependency extends vscode.TreeItem {
-	constructor(label: string, line: number, collapsibleState: vscode.TreeItemCollapsibleState) {
-		super(label, collapsibleState);
+
+	children: Dependency[] = [];
+
+	constructor(label: string, line: number) {
+		super(label, vscode.TreeItemCollapsibleState.None);
+
 		this.command = {
 			title: '',
 			command: 'region-viewer.reveal',

--- a/santacodes-region-viewer/tsconfig.json
+++ b/santacodes-region-viewer/tsconfig.json
@@ -8,6 +8,7 @@
 		],
 		"sourceMap": true,
 		"rootDir": "src",
+		"resolveJsonModule": true,
 		"strict": true   /* enable all strict type-checking options */
 		/* Additional Checks */
 		// "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */


### PR DESCRIPTION
Hi!

I've been looking into this for a few days, and I wonder what you think. I've made some big changes, and I don't want to force it on you, this is your repository after all, and I don't even know what the direction of the project is. I saw your blog post on http://www.santacodes.com/. Maybe you wanted to implement these things yourself and write about the process or something, I don't know.

So feel free to turn me down if you don't like this PR. I can always make my own extension and do "crazy regex stuff" in my own project. 🙂

## The current state
 This branch supports 23 languages, using VSCode's regex expressions (found directly [in the source code](https://github.com/microsoft/vscode/search?p=2&q=folding+markers+start+end&unscoped_q=folding+markers+start+end)) to recognize region starts and ends. We're using the exact VSCode expressions here, so what can be folded should be exactly the same that's displayed in the Region Viewer.

In short, there's a [json file](https://github.com/swift502/vscode-region-viewer/blob/nesting/santacodes-region-viewer/src/markers.json) with regex definitions for each language. If the current file language is on the list, it looks for region markers. This approach feels very organised, easily expandable, and performance friendly.

## The issue

The major issue is that this new approach does not currently read region names. Instead, the entire region definition is displayed. See image, Javascript, CSharp and HTML:

![image](https://user-images.githubusercontent.com/24359130/89061283-bed45c00-d364-11ea-80ac-b4d8e0a02bf7.png)

Instead of always displaying a clean `# Level 1` or `# Region 1`

## My questions for you

1. How important are the pretty region names? We can add "pretty region names" for all languages (using named Regex groups, I tried it and it works), but it will take a lot of time, because I'm not at all familiar with the syntax of about half of the languages on the list. It will take time to properly test it so there's no syntax errors for each language. Or we can let the community implement the languages they use. What do you think?

2. Did you even want to support 23 languages? Maybe it's an overkill for you?

3. Do you like my nesting implementation? Did you even plan on implementing nesting?

Thank you for your time.