### PR TITLE
C language support, readme language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,32 @@
 # Region Viewer Extension
 
-This extension allows you to print a list of regions in a document and select a region to navigate to the document's location.
-
-The languages supported are as follows.
- - TypeScript/JavaScript: `//#region` and `//region`
- - C#: `#region`
- - C/C++: `#pragma region`
- - F#: `//#region`
- - PowerShell: `#region`
- - VB: `#Region`
-
-## Known Issues
-
-None.
+__Region Viewer__ allows you to print a list of regions in a document and select a region to navigate to the document's location.
 
 ![Preview](images/preview.gif)
+
+## Language support
+
+Region Viewer supports all languages which have [folding markers](https://code.visualstudio.com/docs/editor/codebasics#_folding) defined for them. The `[name]` placeholder stands for an optional custom region name.
+
+| Language | Region start | Region end |
+| --- | --- | --- |
+Bat|`::#region [name]` or `REM #region [name]`|`::#endregion` or `REM #endregion`
+C#|`#region [name]`|`#endregion`
+C/C++|`#pragma region [name]`|`#pragma endregion`
+CSS / Less / SCSS|`/*#region [name]*/`|`/*#endregion*/`
+Coffeescript|`#region [name]`|`#endregion`
+F#|`//#region [name]` or `(#region [name])`|`//#endregion` or `(#endregion)`
+Go|`//#region [name]` |`//#endregion`
+HTML / XML|`<!-- #region [name] -->`|`<!-- #endregion -->`
+Java|`//#region [name]`|`//#endregion`
+Markdown|`<!-- #region [name] -->`|`<!-- #endregion -->`
+Perl5|`#region [name]`|`#endregion`
+PHP|`#region [name]`|`#endregion`
+PowerShell|`#region [name]`|`#endregion`
+Python |`#region [name]` or `# region [name]`|`#endregion` or `# endregion`
+Shellscript |`#region [name]` or `# region [name]`|`#endregion` or `# endregion`
+TypeScript / JavaScript|`//#region [name]` |`//#endregion`
+Visual Basic|`#Region [name]`|`#End Region`
+Yaml|`#region [name]` or `# region [name]`|`#endregion` or `# endregion`
+
+The exact regular expressions can be found in this extension's [markers.json](./src/markers.json).

--- a/src/markers.json
+++ b/src/markers.json
@@ -7,6 +7,10 @@
 		"start": "^\\s*#region\\b(?<name>.*)",
 		"end": "^\\s*#endregion\\b"
 	},
+	"c": {
+		"start": "^\\s*#pragma\\s+region\\b(?<name>.*)",
+		"end": "^\\s*#pragma\\s+endregion\\b"
+	},
 	"cpp": {
 		"start": "^\\s*#pragma\\s+region\\b(?<name>.*)",
 		"end": "^\\s*#pragma\\s+endregion\\b"


### PR DESCRIPTION
Expanding the language definitions in readme. I also noticed the C language was missing on list, even though it's the same as C++.

And I removed the "Known issues" section, since we have no known issues. 😃

As always, let me know what you think.

---

I think this is my last pull request. Don't want to take more of your time. And the extension is pretty good at this point.

The only improvements I can think of is adding sort modes (alphabetical or position in document), and possibly upgrading the icon a bit, but that's a matter of taste, so I'll leave it up to you.