### PR TITLE
added AL language

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Region Viewer supports all languages which have [folding markers](https://code.v
 
 | Language | Region start | Region end |
 | --- | --- | --- |
+AL|`[//]#region [name]`|`[//]#endregion`
 Bat|`::#region [name]` or `REM #region [name]`|`::#endregion` or `REM #endregion`
 C#|`#region [name]`|`#endregion`
 C/C++|`#pragma region [name]`|`#pragma endregion`

--- a/src/markers.json
+++ b/src/markers.json
@@ -1,4 +1,8 @@
 {
+	"al": {
+		"start": "^\\s*(?://)?#region\\b(?<name>.*)",
+		"end": "^\\s*(?://)?#endregion\\b"
+	},
 	"bat": {
 		"start": "^\\s*(::\\s*|REM\\s+)#region(?<name>.*)",
 		"end": "^\\s*(::\\s*|REM\\s+)#endregion"


### PR DESCRIPTION
this PR adds region detection for AL language, see https://learn.microsoft.com/en-us/dynamics365/business-central/dev-itpro/developer/directives/devenv-directive-region for details.

I've added a fallback as pre-v6-al language did not supported regions, but I'm a bit curious about the regex for optional slashes.
the override via settings works as expected
```json
    "region-viewer.markers-overrides": {
        "al": {
            "start": "^\\s*(?://)?#region\\b(?<name>.*)",
            "end": "^\\s*(?://)?#endregion\\b"
        },
    }
```